### PR TITLE
재무제표 조회 API에 찜 여부(wished) 표시 기능 추가

### DIFF
--- a/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/controller/FinancialController.java
+++ b/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/controller/FinancialController.java
@@ -1,39 +1,46 @@
 package com.help.stockassistplatform.domain.financial.controller;
 
+import java.util.UUID;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import lombok.RequiredArgsConstructor;
-
-import com.help.stockassistplatform.domain.financial.service.FinancialService;
-import com.help.stockassistplatform.global.common.response.ApiResponse;
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialDetailResponse;
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialListResponse;
+import com.help.stockassistplatform.domain.financial.service.FinancialService;
+import com.help.stockassistplatform.global.common.response.ApiResponse;
+import com.help.stockassistplatform.global.jwt.CustomUser;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/financial")
 @RequiredArgsConstructor
 public class FinancialController {
 
-    private final FinancialService financialService;
+	private final FinancialService financialService;
 
-    @GetMapping
-    public ApiResponse<?> getFinancial(
-            @RequestParam(required = false) String ticker,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "3") int size,
-            @RequestParam(required = false) String sortBy,
-            @RequestParam(defaultValue = "desc") String sort,
-            @RequestParam(required = false) Integer sentiment
-    ) {
-        if (ticker != null && !ticker.isBlank()) {
-            FinancialDetailResponse detail = financialService.getDetailByTicker(ticker);
-            return ApiResponse.success(detail);
-        }
+	@GetMapping
+	public ApiResponse<?> getFinancial(
+		@AuthenticationPrincipal CustomUser user,
+		@RequestParam(required = false) String ticker,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "3") int size,
+		@RequestParam(required = false) String sortBy,
+		@RequestParam(defaultValue = "desc") String sort,
+		@RequestParam(required = false) Integer sentiment
+	) {
+		final UUID userId = user != null ? user.getUserId() : null;
 
-        FinancialListResponse list = financialService.getList(page, size, sortBy, sort, sentiment);
-        return ApiResponse.success(list);
-    }
+		if (ticker != null && !ticker.isBlank()) {
+			FinancialDetailResponse detail = financialService.getDetailByTicker(ticker, userId);
+			return ApiResponse.success(detail);
+		}
+
+		FinancialListResponse list = financialService.getList(page, size, sortBy, sort, sentiment, userId);
+		return ApiResponse.success(list);
+	}
 }

--- a/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/dto/response/FinancialDetailResponse.java
+++ b/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/dto/response/FinancialDetailResponse.java
@@ -4,37 +4,40 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public record FinancialDetailResponse(
-        String name,
-        String ticker,
-        String price,
-        Double change,
-        Integer status,
-        List<FinancialItemResponse> 손익계산서,
-        List<FinancialItemResponse> 대차대조표,
-        List<FinancialItemResponse> 현금흐름표,
-        List<FinancialItemResponse> 주요비율
+	String name,
+	String ticker,
+	String price,
+	Double change,
+	Integer status,
+	List<FinancialItemResponse> 손익계산서,
+	List<FinancialItemResponse> 대차대조표,
+	List<FinancialItemResponse> 현금흐름표,
+	List<FinancialItemResponse> 주요비율,
+	Boolean wished
 ) {
-    public static FinancialDetailResponse from(
-            String name,
-            String ticker,
-            BigDecimal close,
-            Float change,
-            Integer status,
-            List<FinancialItemResponse> income,
-            List<FinancialItemResponse> balance,
-            List<FinancialItemResponse> cash,
-            List<FinancialItemResponse> ratios
-    ) {
-        return new FinancialDetailResponse(
-                name,
-                ticker,
-                close == null ? "-" : close.toPlainString(),
-                change == null ? 1 : Double.valueOf(change),
-                status,
-                income,
-                balance,
-                cash,
-                ratios
-        );
-    }
+	public static FinancialDetailResponse from(
+		String name,
+		String ticker,
+		BigDecimal close,
+		Float change,
+		Integer status,
+		List<FinancialItemResponse> income,
+		List<FinancialItemResponse> balance,
+		List<FinancialItemResponse> cash,
+		List<FinancialItemResponse> ratios,
+		Boolean wished
+	) {
+		return new FinancialDetailResponse(
+			name,
+			ticker,
+			close == null ? "-" : close.toPlainString(),
+			change == null ? 1 : Double.valueOf(change),
+			status,
+			income,
+			balance,
+			cash,
+			ratios,
+			wished
+		);
+	}
 }

--- a/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/service/FinancialService.java
+++ b/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/service/FinancialService.java
@@ -1,28 +1,33 @@
 package com.help.stockassistplatform.domain.financial.service;
 
+import java.util.UUID;
+
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialDetailResponse;
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialListResponse;
 
+import jakarta.annotation.Nullable;
+
 public interface FinancialService {
 
-    /**
-     * 단일 종목의 재무 상세 정보를 반환
-     */
-    FinancialDetailResponse getDetailByTicker(String ticker);
+	/**
+	 * 단일 종목의 재무 상세 정보를 반환
+	 */
+	FinancialDetailResponse getDetailByTicker(String ticker, @Nullable UUID userId);
 
-    /**
-     * (기존) 단순 페이지 조회
-     */
-    FinancialListResponse getListByPage(int page);
+	/**
+	 * (기존) 단순 페이지 조회
+	 */
+	FinancialListResponse getListByPage(int page, @Nullable UUID userId);
 
-    /**
-     * (신규) 정렬, 필터링을 포함한 재무 목록 조회
-     *
-     * @param page      페이지 번호 (1부터 시작)
-     * @param size      페이지 크기
-     * @param sortBy    정렬 기준 (예: "price", "revenue")
-     * @param sort      정렬 방향 ("asc", "desc")
-     * @param sentiment AI 분석 결과 필터링 (예: 1, 0, -1 등)
-     */
-    FinancialListResponse getList(int page, int size, String sortBy, String sort, Integer sentiment);
+	/**
+	 * (신규) 정렬, 필터링을 포함한 재무 목록 조회
+	 *
+	 * @param page      페이지 번호 (1부터 시작)
+	 * @param size      페이지 크기
+	 * @param sortBy    정렬 기준 (예: "price", "revenue")
+	 * @param sort      정렬 방향 ("asc", "desc")
+	 * @param sentiment AI 분석 결과 필터링 (예: 1, 0, -1 등)
+	 */
+	FinancialListResponse getList(int page, int size, String sortBy, String sort, Integer sentiment,
+		@Nullable UUID userId);
 }

--- a/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/service/impl/FinancialServiceImpl.java
+++ b/StockAssistPlatform/src/main/java/com/help/stockassistplatform/domain/financial/service/impl/FinancialServiceImpl.java
@@ -1,7 +1,14 @@
 package com.help.stockassistplatform.domain.financial.service.impl;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -13,10 +20,22 @@ import org.springframework.transaction.annotation.Transactional;
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialDetailResponse;
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialItemResponse;
 import com.help.stockassistplatform.domain.financial.dto.response.FinancialListResponse;
-import com.help.stockassistplatform.domain.financial.entity.*;
+import com.help.stockassistplatform.domain.financial.entity.BalanceSheetView;
+import com.help.stockassistplatform.domain.financial.entity.CashFlowView;
+import com.help.stockassistplatform.domain.financial.entity.FinancialAnalysisView;
+import com.help.stockassistplatform.domain.financial.entity.FinancialRatioView;
+import com.help.stockassistplatform.domain.financial.entity.IncomeStatementView;
+import com.help.stockassistplatform.domain.financial.entity.StockPriceView;
 import com.help.stockassistplatform.domain.financial.mapper.FinancialMapper;
-import com.help.stockassistplatform.domain.financial.repository.*;
+import com.help.stockassistplatform.domain.financial.repository.BalanceSheetViewRepository;
+import com.help.stockassistplatform.domain.financial.repository.CashFlowViewRepository;
+import com.help.stockassistplatform.domain.financial.repository.FinancialAnalysisViewRepository;
+import com.help.stockassistplatform.domain.financial.repository.FinancialRatioViewRepository;
+import com.help.stockassistplatform.domain.financial.repository.IncomeStatementViewRepository;
+import com.help.stockassistplatform.domain.financial.repository.StockPriceViewRepository;
 import com.help.stockassistplatform.domain.financial.service.FinancialService;
+import com.help.stockassistplatform.domain.wishlist.entity.UserWishlistId;
+import com.help.stockassistplatform.domain.wishlist.repository.UserWishlistRepository;
 import com.help.stockassistplatform.global.common.exception.CustomException;
 import com.help.stockassistplatform.global.common.exception.ErrorCode;
 
@@ -27,196 +46,213 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class FinancialServiceImpl implements FinancialService {
 
-    private final StockPriceViewRepository stockPriceViewRepository;
-    private final FinancialAnalysisViewRepository analysisRepository;
-    private final IncomeStatementViewRepository incomeRepository;
-    private final BalanceSheetViewRepository balanceRepository;
-    private final CashFlowViewRepository cashRepository;
-    private final FinancialRatioViewRepository ratioRepository;
+	private final StockPriceViewRepository stockPriceViewRepository;
+	private final FinancialAnalysisViewRepository analysisRepository;
+	private final IncomeStatementViewRepository incomeRepository;
+	private final BalanceSheetViewRepository balanceRepository;
+	private final CashFlowViewRepository cashRepository;
+	private final FinancialRatioViewRepository ratioRepository;
+	private final UserWishlistRepository wishlistRepository;
 
-    private static final int PAGE_SIZE = 3;
+	private static final int PAGE_SIZE = 3;
 
-    private volatile boolean cacheInitialized = false;
-    private List<String> cachedTickerList;
-    private Map<String, StockPriceView> priceMap;
-    private Map<String, FinancialAnalysisView> analysisMap;
-    private Map<String, List<IncomeStatementView>> incomeMap;
-    private Map<String, List<BalanceSheetView>> balanceMap;
-    private Map<String, List<CashFlowView>> cashMap;
-    private Map<String, List<FinancialRatioView>> ratioMap;
+	private volatile boolean cacheInitialized = false;
+	private List<String> cachedTickerList;
+	private Map<String, StockPriceView> priceMap;
+	private Map<String, FinancialAnalysisView> analysisMap;
+	private Map<String, List<IncomeStatementView>> incomeMap;
+	private Map<String, List<BalanceSheetView>> balanceMap;
+	private Map<String, List<CashFlowView>> cashMap;
+	private Map<String, List<FinancialRatioView>> ratioMap;
 
-    @EventListener(ApplicationReadyEvent.class)
-    public void preloadCacheOnStartup() {
-        initializeStaticCache();
-        refreshPriceCache();
-        cacheInitialized = true;
-    }
+	@EventListener(ApplicationReadyEvent.class)
+	public void preloadCacheOnStartup() {
+		initializeStaticCache();
+		refreshPriceCache();
+		cacheInitialized = true;
+	}
 
-     /**
-     * 주가 관련 데이터는 빈번히 변경되므로,
-     * 2분마다 최신 가격 정보를 조회하여 캐시에 갱신합니다.
-     */
-    
-    @Scheduled(fixedDelay = 1000 * 60 * 2)
-    public void refreshPriceCache() {
-        if (cachedTickerList == null || cachedTickerList.isEmpty()) return;
-        this.priceMap = stockPriceViewRepository.findByTickerIn(cachedTickerList).stream()
-                .collect(Collectors.toMap(StockPriceView::getTicker, s -> s));
-    }
+	/**
+	 * 주가 관련 데이터는 빈번히 변경되므로,
+	 * 2분마다 최신 가격 정보를 조회하여 캐시에 갱신합니다.
+	 */
 
-    @Override
-    public FinancialDetailResponse getDetailByTicker(String ticker) {
-        StockPriceView price = stockPriceViewRepository.findOneByTicker(ticker)
-                .orElseThrow(() -> new CustomException(ErrorCode.TICKER_NOT_FOUND));
+	@Scheduled(fixedDelay = 1000 * 60 * 2)
+	public void refreshPriceCache() {
+		if (cachedTickerList == null || cachedTickerList.isEmpty())
+			return;
+		this.priceMap = stockPriceViewRepository.findByTickerIn(cachedTickerList).stream()
+			.collect(Collectors.toMap(StockPriceView::getTicker, s -> s));
+	}
 
-        String name = price.getName();
-        BigDecimal close = price.getPrice();
-        Float change = price.getChange();
+	@Override
+	public FinancialDetailResponse getDetailByTicker(String ticker, UUID userId) {
+		Boolean wished = userId != null &&
+			wishlistRepository.existsById(new UserWishlistId(userId, ticker));
 
-        Integer status = analysisRepository.findLatestByCompanyOrderByPostedAtDesc(ticker)
-                .map(FinancialAnalysisView::getAiAnalysis)
-                .orElse(null);
+		StockPriceView price = stockPriceViewRepository.findOneByTicker(ticker)
+			.orElseThrow(() -> new CustomException(ErrorCode.TICKER_NOT_FOUND));
 
-        List<FinancialItemResponse> incomeList = FinancialMapper.mapIncome(
-                incomeRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
-        List<FinancialItemResponse> balanceList = FinancialMapper.mapBalance(
-                balanceRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
-        List<FinancialItemResponse> cashList = FinancialMapper.mapCash(
-                cashRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
-        List<FinancialItemResponse> ratioList = FinancialMapper.mapRatio(
-                ratioRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
+		String name = price.getName();
+		BigDecimal close = price.getPrice();
+		Float change = price.getChange();
 
-        return FinancialDetailResponse.from(
-                name, ticker, close, change, status,
-                incomeList, balanceList, cashList, ratioList
-        );
-    }
+		Integer status = analysisRepository.findLatestByCompanyOrderByPostedAtDesc(ticker)
+			.map(FinancialAnalysisView::getAiAnalysis)
+			.orElse(null);
 
-    @Override
-    public FinancialListResponse getListByPage(int page) {
-        if (!cacheInitialized) {
-            synchronized (this) {
-                if (!cacheInitialized) {
-                    initializeStaticCache();
-                    refreshPriceCache();
-                    cacheInitialized = true;
-                }
-            }
-        }
+		List<FinancialItemResponse> incomeList = FinancialMapper.mapIncome(
+			incomeRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
+		List<FinancialItemResponse> balanceList = FinancialMapper.mapBalance(
+			balanceRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
+		List<FinancialItemResponse> cashList = FinancialMapper.mapCash(
+			cashRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
+		List<FinancialItemResponse> ratioList = FinancialMapper.mapRatio(
+			ratioRepository.findRecent2ByCompanyOrderByPostedAtDesc(ticker));
 
-        int pageSize = PAGE_SIZE;
-        int offset = (page - 1) * pageSize;
+		return FinancialDetailResponse.from(
+			name, ticker, close, change, status,
+			incomeList, balanceList, cashList, ratioList,
+			wished
+		);
+	}
 
-        if (offset >= cachedTickerList.size()) {
-            throw new CustomException(ErrorCode.NOT_FOUND);
-        }
+	@Override
+	public FinancialListResponse getListByPage(int page, UUID userId) {
+		if (!cacheInitialized) {
+			synchronized (this) {
+				if (!cacheInitialized) {
+					initializeStaticCache();
+					refreshPriceCache();
+					cacheInitialized = true;
+				}
+			}
+		}
 
-        List<String> tickers = cachedTickerList.subList(offset, Math.min(offset + pageSize, cachedTickerList.size()));
+		final Set<String> wishedTickers = (userId == null)
+			? Set.of()
+			: new HashSet<>(wishlistRepository.findTickersByUserId(userId));
 
-        List<FinancialDetailResponse> financials = tickers.stream()
-                .map(this::mapToDetail)
-                .filter(Objects::nonNull)
-                .toList();
+		int pageSize = PAGE_SIZE;
+		int offset = (page - 1) * pageSize;
 
-        boolean hasNext = offset + pageSize < cachedTickerList.size();
+		if (offset >= cachedTickerList.size()) {
+			throw new CustomException(ErrorCode.NOT_FOUND);
+		}
 
-        if (financials.isEmpty()) {
-            throw new CustomException(ErrorCode.NOT_FOUND);
-        }
+		List<String> tickers = cachedTickerList.subList(offset, Math.min(offset + pageSize, cachedTickerList.size()));
 
-        return FinancialListResponse.from(financials, page, hasNext);
-    }
+		List<FinancialDetailResponse> financials = tickers.stream()
+			.map(t -> mapToDetail(t, wishedTickers.contains(t)))
+			.filter(Objects::nonNull)
+			.toList();
 
-    @Override
-    public FinancialListResponse getList(int page, int size, String sortBy, String sort, Integer sentiment) {
-        if (!cacheInitialized) {
-            synchronized (this) {
-                if (!cacheInitialized) {
-                    initializeStaticCache();
-                    refreshPriceCache();
-                    cacheInitialized = true;
-                }
-            }
-        }
+		boolean hasNext = offset + pageSize < cachedTickerList.size();
 
-        List<String> filteredTickers = cachedTickerList.stream()
-                .filter(ticker -> {
-                    if (sentiment == null) return true;
-                    FinancialAnalysisView analysis = analysisMap.get(ticker);
-                    return analysis != null && sentiment.equals(analysis.getAiAnalysis());
-                })
-                .collect(Collectors.toList());
+		if (financials.isEmpty()) {
+			throw new CustomException(ErrorCode.NOT_FOUND);
+		}
 
-        Comparator<String> comparator = Comparator.comparing(ticker -> {
-            if ("revenue".equalsIgnoreCase(sortBy)) {
-                List<IncomeStatementView> incomeList = incomeMap.get(ticker);
-                if (incomeList != null && !incomeList.isEmpty()) {
-                    BigDecimal revenue = incomeList.get(0).getTotalRevenue();
-                    return revenue != null ? revenue : BigDecimal.ZERO;
-                }
-                return BigDecimal.ZERO;
-            }
-            StockPriceView price = priceMap.get(ticker);
-            return price != null ? price.getPrice() : BigDecimal.ZERO;
-        });
+		return FinancialListResponse.from(financials, page, hasNext);
+	}
 
-        if ("desc".equalsIgnoreCase(sort)) {
-            comparator = comparator.reversed();
-        }
-        filteredTickers.sort(comparator);
+	@Override
+	public FinancialListResponse getList(int page, int size, String sortBy, String sort, Integer sentiment,
+		UUID userId) {
+		if (!cacheInitialized) {
+			synchronized (this) {
+				if (!cacheInitialized) {
+					initializeStaticCache();
+					refreshPriceCache();
+					cacheInitialized = true;
+				}
+			}
+		}
 
-        int offset = (page - 1) * size;
-        int end = Math.min(offset + size, filteredTickers.size());
+		final Set<String> wishedTickers = (userId == null)
+			? Set.of()
+			: new HashSet<>(wishlistRepository.findTickersByUserId(userId));
 
-        if (offset >= filteredTickers.size()) {
-            throw new CustomException(ErrorCode.NOT_FOUND);
-        }
+		List<String> filteredTickers = cachedTickerList.stream()
+			.filter(ticker -> {
+				if (sentiment == null)
+					return true;
+				FinancialAnalysisView analysis = analysisMap.get(ticker);
+				return analysis != null && sentiment.equals(analysis.getAiAnalysis());
+			})
+			.collect(Collectors.toList());
 
-        List<String> pagedTickers = filteredTickers.subList(offset, end);
+		Comparator<String> comparator = Comparator.comparing(ticker -> {
+			if ("revenue".equalsIgnoreCase(sortBy)) {
+				List<IncomeStatementView> incomeList = incomeMap.get(ticker);
+				if (incomeList != null && !incomeList.isEmpty()) {
+					BigDecimal revenue = incomeList.get(0).getTotalRevenue();
+					return revenue != null ? revenue : BigDecimal.ZERO;
+				}
+				return BigDecimal.ZERO;
+			}
+			StockPriceView price = priceMap.get(ticker);
+			return price != null ? price.getPrice() : BigDecimal.ZERO;
+		});
 
-        List<FinancialDetailResponse> financials = pagedTickers.stream()
-                .map(this::mapToDetail)
-                .filter(Objects::nonNull)
-                .toList();
+		if ("desc".equalsIgnoreCase(sort)) {
+			comparator = comparator.reversed();
+		}
+		filteredTickers.sort(comparator);
 
-        boolean hasNext = end < filteredTickers.size();
+		int offset = (page - 1) * size;
+		int end = Math.min(offset + size, filteredTickers.size());
 
-        return FinancialListResponse.from(financials, page, hasNext);
-    }
+		if (offset >= filteredTickers.size()) {
+			throw new CustomException(ErrorCode.NOT_FOUND);
+		}
 
-    private FinancialDetailResponse mapToDetail(String ticker) {
-        StockPriceView stock = priceMap.get(ticker);
-        if (stock == null || !incomeMap.containsKey(ticker) || !balanceMap.containsKey(ticker)
-                || !cashMap.containsKey(ticker) || !ratioMap.containsKey(ticker))
-            return null;
+		List<String> pagedTickers = filteredTickers.subList(offset, end);
 
-        return FinancialDetailResponse.from(
-                stock.getName(), ticker, stock.getPrice(), stock.getChange(),
-                Optional.ofNullable(analysisMap.get(ticker)).map(FinancialAnalysisView::getAiAnalysis).orElse(null),
-                FinancialMapper.mapIncome(incomeMap.get(ticker)),
-                FinancialMapper.mapBalance(balanceMap.get(ticker)),
-                FinancialMapper.mapCash(cashMap.get(ticker)),
-                FinancialMapper.mapRatio(ratioMap.get(ticker))
-        );
-    }
+		List<FinancialDetailResponse> financials = pagedTickers.stream()
+			.map(t -> mapToDetail(t, wishedTickers.contains(t)))
+			.filter(Objects::nonNull)
+			.toList();
 
-    @Scheduled(fixedDelay = 1000 * 60 * 60 * 2)
-    protected void initializeStaticCache() {
-        this.cachedTickerList = stockPriceViewRepository.findAllTickersSorted();
+		boolean hasNext = end < filteredTickers.size();
 
-        this.analysisMap = analysisRepository.findLatestByTickers(cachedTickerList).stream()
-                .collect(Collectors.toMap(FinancialAnalysisView::getCompany, a -> a));
+		return FinancialListResponse.from(financials, page, hasNext);
+	}
 
-        this.incomeMap = incomeRepository.findRecent2ByTickers(cachedTickerList).stream()
-                .collect(Collectors.groupingBy(IncomeStatementView::getCompany));
+	private FinancialDetailResponse mapToDetail(String ticker, Boolean wished) {
+		StockPriceView stock = priceMap.get(ticker);
+		if (stock == null || !incomeMap.containsKey(ticker) || !balanceMap.containsKey(ticker)
+			|| !cashMap.containsKey(ticker) || !ratioMap.containsKey(ticker))
+			return null;
 
-        this.balanceMap = balanceRepository.findRecent2ByTickers(cachedTickerList).stream()
-                .collect(Collectors.groupingBy(BalanceSheetView::getCompany));
+		return FinancialDetailResponse.from(
+			stock.getName(), ticker, stock.getPrice(), stock.getChange(),
+			Optional.ofNullable(analysisMap.get(ticker)).map(FinancialAnalysisView::getAiAnalysis).orElse(null),
+			FinancialMapper.mapIncome(incomeMap.get(ticker)),
+			FinancialMapper.mapBalance(balanceMap.get(ticker)),
+			FinancialMapper.mapCash(cashMap.get(ticker)),
+			FinancialMapper.mapRatio(ratioMap.get(ticker)),
+			wished
+		);
+	}
 
-        this.cashMap = cashRepository.findRecent2ByTickers(cachedTickerList).stream()
-                .collect(Collectors.groupingBy(CashFlowView::getCompany));
+	@Scheduled(fixedDelay = 1000 * 60 * 60 * 2)
+	protected void initializeStaticCache() {
+		this.cachedTickerList = stockPriceViewRepository.findAllTickersSorted();
 
-        this.ratioMap = ratioRepository.findRecent2ByTickers(cachedTickerList).stream()
-                .collect(Collectors.groupingBy(FinancialRatioView::getCompany));
-    }
+		this.analysisMap = analysisRepository.findLatestByTickers(cachedTickerList).stream()
+			.collect(Collectors.toMap(FinancialAnalysisView::getCompany, a -> a));
+
+		this.incomeMap = incomeRepository.findRecent2ByTickers(cachedTickerList).stream()
+			.collect(Collectors.groupingBy(IncomeStatementView::getCompany));
+
+		this.balanceMap = balanceRepository.findRecent2ByTickers(cachedTickerList).stream()
+			.collect(Collectors.groupingBy(BalanceSheetView::getCompany));
+
+		this.cashMap = cashRepository.findRecent2ByTickers(cachedTickerList).stream()
+			.collect(Collectors.groupingBy(CashFlowView::getCompany));
+
+		this.ratioMap = ratioRepository.findRecent2ByTickers(cachedTickerList).stream()
+			.collect(Collectors.groupingBy(FinancialRatioView::getCompany));
+	}
 }


### PR DESCRIPTION
## 개요

사용자가 재무제표 상세 및 목록을 조회할 때, 해당 종목을 찜했는지 여부(wished)를 함께 응답하도록 기능을 추가했습니다.

## 주요 변경 사항

- `FinancialDetailResponse` DTO에 `wished: boolean` 필드 추가
- 단건 API (`GET /api/financial?ticker=...`)에서 로그인 사용자의 찜 여부 조회 및 응답 반영
- 목록 API (`GET /api/financial`)에서도 찜 여부 일괄 조회 후 각 종목별로 표시
- 목록 조회 시 사용자 위시리스트를 Set으로 한번만 조회 후 contains 체크 (O(1))
- `FinancialService` 인터페이스 및 구현체에 `UUID userId` 파라미터 추가
- Controller에서 `@AuthenticationPrincipal`을 통해 `userId` 전달 (비로그인 시 null 처리)

## API 응답 예시

```json
{
  "name": "NVIDIA",
  "ticker": "NVDA",
  "price": "123.45",
  "change": 1.23,
  "status": 2,
  "손익계산서": [...],
  "대차대조표": [...],
  "현금흐름표": [...],
  "주요비율": [...],
  "wished": true
}
